### PR TITLE
Add a CI workflow for multicoretests

### DIFF
--- a/.github/workflows/multicoretests.yml
+++ b/.github/workflows/multicoretests.yml
@@ -1,0 +1,73 @@
+# Run the multicoretests testsuite if PR is labelled with run-multicoretests
+name: Run multicoretests testsuite
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Restrict the GITHUB_TOKEN
+permissions: {}
+
+# See build.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  multicoretests:
+    if: contains(github.event.pull_request.labels.*.name, 'run-multicoretests')
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        include:
+          - profile: dev
+            ocamlrunparam: b
+          - profile: debug-runtime
+            ocamlrunparam: b,s=4096
+    steps:
+      - name: Checkout OCaml
+        uses: actions/checkout@v4
+        with:
+          path: ocaml
+          persist-credentials: false
+      - name: Configure, build and install OCaml
+        run: |
+          bash -xe ocaml/tools/ci/actions/multicoretests.sh ocaml
+      - name: Checkout multicoretests
+        uses: actions/checkout@v4
+        with:
+          repository: ocaml-multicore/multicoretests
+          ref: 0.4
+          path: multicoretests
+          persist-credentials: false
+      - name: Checkout QCheck
+        uses: actions/checkout@v4
+        with:
+          repository: c-cube/qcheck
+          ref: v0.22
+          path: multicoretests/qcheck
+          persist-credentials: false
+      - name: Checkout dune
+        uses: actions/checkout@v4
+        with:
+          repository: ocaml/dune
+          ref: 3.16.0
+          path: dune
+          persist-credentials: false
+      - name: Build and install dune
+        run: |
+          bash -xe ocaml/tools/ci/actions/multicoretests.sh dune
+      - name: Show the configuration
+        run: |
+          bash ocaml/tools/ci/actions/multicoretests.sh show_config
+      - name: Build the test suite
+        env:
+          DUNE_PROFILE: ${{ matrix.profile }}
+          OCAMLRUNPARAM: ${{ matrix.ocamlrunparam }}
+        run: |
+          bash -xe ocaml/tools/ci/actions/multicoretests.sh build
+      - name: Run the multicore test suite
+        env:
+          DUNE_PROFILE: ${{ matrix.profile }}
+          OCAMLRUNPARAM: ${{ matrix.ocamlrunparam }}
+        run: |
+          bash -xe ocaml/tools/ci/actions/multicoretests.sh testsuite

--- a/tools/ci/actions/multicoretests.sh
+++ b/tools/ci/actions/multicoretests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                           Samuel Hym, Tarides                          *
+#*                                                                        *
+#*   Copyright 2024 Tarides                                               *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+set -e
+
+OCAMLDIR=ocaml
+DUNEDIR=dune
+MULTICORETESTSDIR=multicoretests
+
+export PREFIX="$HOME/local"
+export PATH="$PREFIX/bin:$PATH"
+
+fatal() {
+  printf %s "$1"
+  exit 1
+}
+
+build_ocaml() {
+  # We let build.yml test for warnings
+  cd "$OCAMLDIR"
+  if ! ./configure --disable-warn-error --disable-stdlib-manpages \
+      --disable-ocamltest --disable-ocamldoc --prefix="$PREFIX" ; then
+    cat config.log
+    exit 1
+  fi
+
+  make -j
+  make install
+}
+
+build_dune() {
+  cd "$DUNEDIR"
+  make release
+  make install PREFIX="$PREFIX"
+}
+
+show_config() {
+  set -x
+  ocamlc -config
+  dune --version
+}
+
+build_testsuite() {
+  cd "$MULTICORETESTSDIR"
+  dune build
+}
+
+run_testsuite() {
+  export QCHECK_MSG_INTERVAL=60
+  cd "$MULTICORETESTSDIR"
+  dune build @ci -j1 --no-buffer --display=quiet --cache=disabled \
+    --error-reporting=twice
+}
+
+case "$1" in
+  ocaml)
+    build_ocaml
+    ;;
+  dune)
+    build_dune
+    ;;
+  show_config)
+    show_config
+    ;;
+  build)
+    build_testsuite
+    ;;
+  testsuite)
+    run_testsuite
+    ;;
+  *)
+    fatal "Unknown command '$1'"
+    ;;
+esac


### PR DESCRIPTION
This PR is joint work between @jmid and @shym. It adds a CI workflow to trigger a run of `multicoretests`, a property-based test suite. Adding the label `run-multicoretests` to a PR will trigger a run of the test suite on Linux with and without the debug runtime. We hope that the test suite can continue to be helpful, by making it more easily available to OCaml compiler developers.


## On `multicoretests`

`multicoretests` was developed in an effort to test
- the (then still new) OCaml5 runtime and
- the existing `Stdlib` for parallelism safety

The test suite has helped identify a range of issues in both of these
https://github.com/ocaml-multicore/multicoretests#issues
as well as in documentation and in Windows support.

The tests are (pseudo) randomized, meaning that a different stream of test inputs is attempted on each rerun. By providing a test run with the same seed, the same sequence of test inputs will thus be exercised.

The test suite consists of both
- sequential tests,
- parallel tests to maximize trouble by simultaniously running domains, and
- stress tests of `Domain`, `Thread`, and their combination

Nevertheless, we have now reached a point where subsequent runs yield 'all green' and offer a stable outcome. Any CI red light should thus be inspected.


## On the PR itself

The test suite requires only `qcheck-core` and `dune` to build and run. The PR therefore checks these out and builds and runs the test suite. To prevent surprises, both use the latest stable public release (qcheck-core.0.22 and dune.3.16).

For a start we propose a workflow with just two platform configurations: A regular Linux run and a debug-runtime run. We regularly test numerous other combinations (bytecode, framepointers, 32-bit, macOS intel+ARM, MinGW, Cygwin, MSVC, ...) that can be added later if there's interest.

The test suite is sensitive to parallelism, as the parallel tests aim to maximize trouble by running parallel domains as much on top of each other as possible. For this reason, we favour running only one job at a time (`-j1`) on [the standard GitHub-hosted runners with 3-4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
