### PR TITLE
Add a dummy `caml_debugger_saved_instruction` when `HAS_SOCKETS` is false

### DIFF
--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -43,6 +43,16 @@ void caml_debugger_init(void)
 {
 }
 
+opcode_t caml_debugger_saved_instruction(code_t pc)
+{
+  /* Raise a fatal error in the should-not-happen case where this function
+   * would be called without a socket, so that the execution does not branch
+   * to opcode 0 */
+  caml_fatal_error("cannot execute debugger instructions"
+                   " without a debugger connection socket\n");
+  return 0;
+}
+
 void caml_debugger(enum event_kind event, value param)
 {
 }


### PR DESCRIPTION
The `caml_debugger_saved_instruction` function is called unconditionally in `runtime/interp.c` to implement the debugger-specific instructions. This patch provides a dummy implementation for that function, alongside the other `caml_debugger_*` functions, so that the interpreter can be built in the uncommon setups with no available socket implementation.

This was encountered while building a compiler for MirageOS.
This doesn’t require a changelog entry.